### PR TITLE
POM Clean Up to Fix Local Build Failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,27 @@
 
 	<properties>
         <muleJavaEeBomVersion>4.6.0</muleJavaEeBomVersion>
+        <munit.extensions.maven.plugin.version>1.2.0</munit.extensions.maven.plugin.version>
     </properties>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.mulesoft.munit</groupId>
+				<artifactId>munit-extensions-maven-plugin</artifactId>
+				<version>${munit.extensions.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<phase>integration-test</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -99,15 +118,16 @@
 			<version>5.9.2</version>
 		</dependency>
 	</dependencies>
-<<<<<<< HEAD
 
 	<repositories>
+	
+	
 		<repository>
-			<id>anypoint-exchange-v3</id>
-			<name>Anypoint Exchange V3</name>
-			<url>https://maven.eu1.anypoint.mulesoft.com/api/v3/maven</url>
-			<layout>default</layout>
+			<id>mule-releases</id>
+			<name>Nexus Public Releases</name>
+			<url>https://repository-master.mulesoft.org/nexus/content/repositories/releases/</url>
 		</repository>
+
 	</repositories>
 	<pluginRepositories>
 		<pluginRepository>
@@ -120,20 +140,6 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
-	<distributionManagement>
-		<snapshotRepository>
-			<id>exchange-repository</id>
-			<name>Exchange Repository</name>
-			<url>https://maven.anypoint.mulesoft.com/api/v1/organizations/9c7c42b3-1b21-4ec1-9183-047ec0921663/maven</url>
-			<layout>default</layout>
-		</snapshotRepository>
-		<repository>
-			<id>exchange-repository</id>
-			<name>Exchange Repository</name>
-			<url>https://maven.anypoint.mulesoft.com/api/v1/organizations/9c7c42b3-1b21-4ec1-9183-047ec0921663/maven</url>
-			<layout>default</layout>
-		</repository>
-	</distributionManagement>
-=======
->>>>>>> master
+
+
 </project>


### PR DESCRIPTION
While building the connector on local, there was below error after making required changes in POM resolved the issues 

[ERROR] Failed to execute goal com.mulesoft.munit:munit-extensions-maven-plugin:1.1.1:test (default-test) on project mac-web-crawler: Execution default-test of goal com.mulesoft.munit:munit-extensions-maven-plugin:1.1.1:test failed: Plugin com.mulesoft.munit:munit-extensions-maven-plugin:1.1.1 or one of its dependencies could not be resolved: Could not transfer artifact com.mulesoft.munit:munit-remote:jar:jar-with-dependencies:2.3.2 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [mulesoft-plugin-releases (http://repository.mulesoft.org/releases/, default, releases+snapshots), mulesoft-plugin-snapshots (http://repository.mulesoft.org/snapshots/, default, releases+snapshots), mule-releases (http://repository.mulesoft.org/releases/, default, releases+snapshots)] -> [Help 1]