### PR TITLE
W-22465125 - add Remote WebDriver fetch path

### DIFF
--- a/src/main/java/org/mule/extension/webcrawler/internal/config/WebCrawlerConfiguration.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/config/WebCrawlerConfiguration.java
@@ -1,6 +1,7 @@
 package org.mule.extension.webcrawler.internal.config;
 
 import org.mule.extension.webcrawler.internal.connection.http.HttpConnectionProvider;
+import org.mule.extension.webcrawler.internal.connection.webdriver.RemoteWebDriverConnectionProvider;
 import org.mule.extension.webcrawler.internal.operation.CrawlOperations;
 import org.mule.extension.webcrawler.internal.operation.PageOperations;
 import org.mule.extension.webcrawler.internal.operation.SearchOperations;
@@ -12,7 +13,7 @@ import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
  * operations since they represent something core from the extension.
  */
 @org.mule.runtime.extension.api.annotation.Configuration(name = "config")
-@ConnectionProviders({HttpConnectionProvider.class})
+@ConnectionProviders({HttpConnectionProvider.class, RemoteWebDriverConnectionProvider.class})
 @org.mule.runtime.extension.api.annotation.Operations({CrawlOperations.class, PageOperations.class, SearchOperations.class})
 public class WebCrawlerConfiguration {
 

--- a/src/main/java/org/mule/extension/webcrawler/internal/connection/WebCrawlerConnection.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/connection/WebCrawlerConnection.java
@@ -1,18 +1,8 @@
 package org.mule.extension.webcrawler.internal.connection;
 
-import org.mule.extension.webcrawler.internal.config.PageLoadOptions;
-
-import java.io.InputStream;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-
 public interface WebCrawlerConnection {
 
   String getUserAgent();
+
   String getReferrer();
-
-  Integer getUrlStatusCode(String url, String currentReferrer) throws ExecutionException, InterruptedException;
-
-  InputStream getPageSource(String url, String currentReferrer, PageLoadOptions pageLoadOptions) throws ExecutionException, InterruptedException;
-
 }

--- a/src/main/java/org/mule/extension/webcrawler/internal/connection/http/HttpConnection.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/connection/http/HttpConnection.java
@@ -1,117 +1,42 @@
 package org.mule.extension.webcrawler.internal.connection.http;
 
-import org.mule.extension.webcrawler.internal.config.PageLoadOptions;
 import org.mule.extension.webcrawler.internal.connection.WebCrawlerConnection;
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.http.api.client.HttpClient;
-import org.mule.runtime.http.api.client.HttpRequestOptions;
-import org.mule.runtime.http.api.domain.message.request.HttpRequest;
-import org.mule.runtime.http.api.domain.message.request.HttpRequestBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.InputStream;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 public class HttpConnection implements WebCrawlerConnection {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(HttpConnection.class);
-
-  private HttpClient httpClient;
-  private String userAgent;
-  private String referrer;
-  private int timeout;
+  private final HttpClient httpClient;
+  private final String userAgent;
+  private final String referrer;
+  private final int timeout;
 
   public HttpConnection(HttpClient httpClient, int timeout, String userAgent, String referrer) {
-
     this.httpClient = httpClient;
     this.userAgent = userAgent;
     this.referrer = referrer;
     this.timeout = timeout;
   }
 
+  public HttpClient getHttpClient() {
+    return httpClient;
+  }
+
+  public int getTimeout() {
+    return timeout;
+  }
+
+  @Override
   public String getUserAgent() {
     return userAgent;
   }
 
+  @Override
   public String getReferrer() {
     return referrer;
   }
 
   public boolean validate() throws ConnectionException {
     return true;
-  }
-
-  @Override
-  public InputStream getPageSource(String url, String currentReferrer, PageLoadOptions pageLoadOptions) throws ExecutionException, InterruptedException {
-
-    LOGGER.debug(String.format("Retrieving page source for url %s using http client (wait %s millisec)", url, pageLoadOptions.getWaitOnPageLoad()));
-    if(pageLoadOptions.getWaitOnPageLoad() != null && pageLoadOptions.getWaitOnPageLoad().longValue() > 0L) {
-
-      throw new RuntimeException("Wait duration is not supported for HttpConnection");
-    }
-
-    HttpRequestBuilder requestBuilder = HttpRequest.builder()
-        .method("GET")
-        .uri(url);
-
-    if (this.userAgent != null) {
-      requestBuilder.addHeader("User-Agent", this.userAgent);
-    }
-
-    if (currentReferrer != null) {
-      requestBuilder.addHeader("Referrer", currentReferrer);
-    }
-
-    HttpRequest request = requestBuilder.build();
-
-    HttpRequestOptions options = HttpRequestOptions.builder()
-        .responseTimeout(timeout != 0 ? timeout : 10000)
-        .build();
-
-    return httpClient.sendAsync(request, options)
-        .thenApply(response -> {
-          if (response.getStatusCode() == 200) {
-            return response.getEntity().getContent();
-          } else {
-            throw new RuntimeException(String.format("%s: %s",response.getStatusCode(), response.getReasonPhrase()));
-          }
-        })
-        .exceptionally(e -> {
-          throw new RuntimeException(e);
-        }).get();
-  }
-
-  @Override
-  public Integer getUrlStatusCode(String url, String currentReferrer) throws ExecutionException, InterruptedException {
-
-    LOGGER.debug(String.format("Checking url status for %s using http client", url));
-
-    HttpRequestBuilder requestBuilder = HttpRequest.builder()
-        .method("HEAD")
-        .uri(url);
-
-    if (this.userAgent != null) {
-      requestBuilder.addHeader("User-Agent", this.userAgent);
-    }
-
-    if (currentReferrer != null) {
-      requestBuilder.addHeader("Referrer", currentReferrer);
-    }
-
-    HttpRequest request = requestBuilder.build();
-
-    HttpRequestOptions options = HttpRequestOptions.builder()
-        .responseTimeout(timeout != 0 ? timeout : 10000)
-        .build();
-
-    return httpClient.sendAsync(request, options)
-        .thenApply(response -> {
-          return response.getStatusCode();
-        })
-        .exceptionally(e -> {
-          throw new RuntimeException(e);
-        }).get();
   }
 }

--- a/src/main/java/org/mule/extension/webcrawler/internal/connection/webdriver/RemoteWebDriverConnection.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/connection/webdriver/RemoteWebDriverConnection.java
@@ -1,0 +1,120 @@
+package org.mule.extension.webcrawler.internal.connection.webdriver;
+
+import org.mule.extension.webcrawler.internal.connection.WebCrawlerConnection;
+import org.mule.runtime.api.connection.ConnectionException;
+import org.openqa.selenium.NoSuchSessionException;
+import org.openqa.selenium.SessionNotCreatedException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RemoteWebDriverConnection implements WebCrawlerConnection {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RemoteWebDriverConnection.class);
+
+  private final RemoteWebDriverConnectionProvider provider;
+  private final String userAgent;
+  private final String referrer;
+
+  // volatile is required because two synchronized methods (restartDriverIfDropped and dropDeadSession)
+  // write to driver, but withDriver reads it without holding the lock at the read site.
+  private volatile WebDriver driver;
+
+  public RemoteWebDriverConnection(RemoteWebDriverConnectionProvider provider, WebDriver driver, String userAgent,
+                                   String referrer) {
+    this.provider = provider;
+    this.driver = driver;
+    this.userAgent = userAgent;
+    this.referrer = referrer;
+  }
+
+  @Override
+  public String getUserAgent() {
+    return userAgent;
+  }
+
+  @Override
+  public String getReferrer() {
+    return referrer;
+  }
+
+  /**
+   * Runs {@code action} against the cached {@link WebDriver}, centralising session-fatal recovery so callers do not
+   * have to handle it. On a session-fatal error the driver reference is dropped without {@link WebDriver#quit()}, so
+   * the next call rebuilds via the provider.
+   */
+  public <T> T withDriver(WebDriverExecutable<T> action) throws ConnectionException {
+    restartDriverIfDropped();
+    try {
+      return action.execute(driver);
+    } catch (Exception e) {
+      if (isSessionFatal(e)) {
+        LOGGER.warn("WebDriver session appears dead ({}: {}). Dropping driver without quit() so the next call rebuilds.",
+            e.getClass().getSimpleName(), e.getMessage());
+        dropDeadSession();
+      }
+      if (e instanceof RuntimeException) {
+        throw (RuntimeException) e;
+      }
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Re-creates the driver if a previous call dropped it after a session-fatal error.
+   */
+  private synchronized void restartDriverIfDropped() throws ConnectionException {
+    if (driver == null) {
+      driver = provider.createNewWebDriver();
+    }
+  }
+
+  // Skip quit() — calling DELETE on a session the worker has lost stalls until the worker's HTTP responseTimeout
+  // fires (~120s on CloudHub remote-browser today). The worker's TTL reaper cleans up the orphan instead.
+  private synchronized void dropDeadSession() {
+    if (driver == null) {
+      return;
+    }
+    driver = null;
+  }
+
+  /**
+   * Quits the driver gracefully. Invoked by the {@link RemoteWebDriverConnectionProvider} on disconnect.
+   */
+  public synchronized void closeDriver() {
+    if (driver == null) {
+      return;
+    }
+    try {
+      driver.quit();
+    } catch (Exception e) {
+      LOGGER.warn("Error while quitting remote WebDriver: {}", e.getMessage());
+    } finally {
+      driver = null;
+    }
+  }
+
+  // True when the throwable indicates the WebDriver session is unrecoverable.
+  // Covers Selenium's typed session exceptions and WebDriverException chains whose message matches
+  // known session-loss modes (CloudHub remote-browser sentinel, server-rejected session id, session-route timeouts).
+  private boolean isSessionFatal(Throwable t) {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      if (cause instanceof SessionNotCreatedException || cause instanceof NoSuchSessionException) {
+        return true;
+      }
+      if (cause instanceof WebDriverException) {
+        String msg = cause.getMessage();
+        if (msg != null) {
+          String lower = msg.toLowerCase();
+          if (lower.contains("webdriver-unavailable")
+              || lower.contains("invalid session id")
+              || (lower.contains("timeout exceeded") && lower.contains("/session/"))) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/connection/webdriver/RemoteWebDriverConnectionProvider.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/connection/webdriver/RemoteWebDriverConnectionProvider.java
@@ -1,0 +1,124 @@
+package org.mule.extension.webcrawler.internal.connection.webdriver;
+
+import org.mule.extension.webcrawler.internal.helper.provider.UserAgentNameProvider;
+import org.mule.runtime.api.connection.CachedConnectionProvider;
+import org.mule.runtime.api.connection.ConnectionException;
+import org.mule.runtime.api.connection.ConnectionValidationResult;
+import org.mule.runtime.api.meta.ExpressionSupport;
+import org.mule.runtime.extension.api.annotation.Alias;
+import org.mule.runtime.extension.api.annotation.Expression;
+import org.mule.runtime.extension.api.annotation.param.Optional;
+import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
+import org.mule.runtime.extension.api.annotation.param.display.Example;
+import org.mule.runtime.extension.api.annotation.param.display.Placement;
+import org.mule.runtime.extension.api.annotation.param.display.Summary;
+import org.mule.runtime.extension.api.annotation.values.OfValues;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Connection provider for the Remote WebDriver fetch path. Spins up a Selenium {@link RemoteWebDriver} pointed at the configured
+ * remote endpoint (Selenium Grid 4, standalone ChromeDriver, BrowserStack/Sauce Labs, or a CloudHub-hosted remote-browser app).
+ *
+ * <p>
+ * Browser must be reachable as a Chromium-family W3C WebDriver endpoint; {@link ChromeOptions} is used unconditionally, so
+ * non-Chromium grids will fail at session creation.
+ * </p>
+ */
+@Alias("remote-webdriver-connection")
+@DisplayName("Remote WebDriver")
+public class RemoteWebDriverConnectionProvider implements CachedConnectionProvider<RemoteWebDriverConnection> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RemoteWebDriverConnectionProvider.class);
+
+  @Parameter
+  @DisplayName("Remote WebDriver URL")
+  @Summary("URL of the remote Selenium WebDriver endpoint (e.g. Selenium Grid, standalone ChromeDriver, BrowserStack, "
+      + "or a CloudHub-hosted remote-browser app). Chromium-only (Chrome, Chromium, Edge).")
+  @Placement(order = 1)
+  @Example("https://remote-browser.example.com")
+  private String remoteUrl;
+
+  @Parameter
+  @Alias("userAgent")
+  @DisplayName("User agent")
+  @Summary("Overrides the browser user-agent for all requests.")
+  @Placement(order = 2)
+  @Expression(ExpressionSupport.SUPPORTED)
+  @OfValues(UserAgentNameProvider.class)
+  @Optional
+  private String userAgent;
+
+  @Parameter
+  @Alias("referrer")
+  @DisplayName("Referrer")
+  @Summary("Sets the Referer header for navigations.")
+  @Placement(order = 3)
+  @Expression(ExpressionSupport.SUPPORTED)
+  @Example("https://www.google.com")
+  @Optional
+  private String referrer;
+
+  @Override
+  public RemoteWebDriverConnection connect() throws ConnectionException {
+    WebDriver driver = createNewWebDriver();
+    return new RemoteWebDriverConnection(this, driver, userAgent, referrer);
+  }
+
+  @Override
+  public void disconnect(RemoteWebDriverConnection connection) {
+    if (connection != null) {
+      connection.closeDriver();
+    }
+  }
+
+  @Override
+  public ConnectionValidationResult validate(RemoteWebDriverConnection connection) {
+    return ConnectionValidationResult.success();
+  }
+
+  /**
+   * Spins up a fresh {@link RemoteWebDriver}. Called both at initial connect time and from
+   * {@link RemoteWebDriverConnection#withDriver} after a session-fatal error has dropped the previous driver.
+   */
+  public WebDriver createNewWebDriver() throws ConnectionException {
+    try {
+      ChromeOptions options = new ChromeOptions();
+      options.addArguments("--headless=new");
+      options.addArguments("--no-sandbox");
+      options.addArguments("--disable-gpu");
+      options.addArguments("--disable-dev-shm-usage");
+      options.addArguments("--disable-extensions");
+      options.addArguments("--allow-running-insecure-content");
+      if (userAgent != null && !userAgent.isEmpty()) {
+        options.addArguments("--user-agent=" + userAgent);
+      }
+      if (referrer != null && !referrer.isEmpty()) {
+        options.addArguments("--referer=" + referrer);
+      }
+      WebDriver driver = buildDriver(new URL(remoteUrl), options);
+      LOGGER.info("Connected to remote WebDriver at {}", remoteUrl);
+      return driver;
+    } catch (MalformedURLException e) {
+      throw new ConnectionException("Invalid Remote WebDriver URL: " + remoteUrl, e);
+    } catch (Exception e) {
+      throw new ConnectionException("Failed to create remote WebDriver at " + remoteUrl + ": " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Constructs the actual remote driver. Extracted as a package-private seam so a future test can substitute it without standing
+   * up a live worker.
+   */
+  WebDriver buildDriver(URL url, ChromeOptions options) {
+    return new RemoteWebDriver(url, options);
+  }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/connection/webdriver/WebDriverExecutable.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/connection/webdriver/WebDriverExecutable.java
@@ -1,0 +1,13 @@
+package org.mule.extension.webcrawler.internal.connection.webdriver;
+
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Lambda body executed inside {@link RemoteWebDriverConnection#withDriver(WebDriverExecutable)} so the connection can
+ * centralise session-fatal recovery around any caller's driver interaction.
+ */
+@FunctionalInterface
+public interface WebDriverExecutable<T> {
+
+  T execute(WebDriver driver) throws Exception;
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/crawler/mule/MuleCrawler.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/crawler/mule/MuleCrawler.java
@@ -11,6 +11,7 @@ import org.mule.extension.webcrawler.internal.constant.Constants.RegexUrlsFilter
 import org.mule.extension.webcrawler.internal.crawler.Crawler;
 import org.mule.extension.webcrawler.internal.error.WebCrawlerErrorType;
 import org.mule.extension.webcrawler.internal.helper.page.PageHelper;
+import org.mule.extension.webcrawler.internal.service.factory.PageFetchServiceFactory;
 import org.mule.extension.webcrawler.internal.util.URLUtils;
 import org.mule.extension.webcrawler.internal.util.Utils;
 import org.mule.runtime.extension.api.exception.ModuleException;
@@ -66,8 +67,9 @@ public class MuleCrawler extends Crawler {
         // add delay
         Utils.addDelay(configuration.getCrawlerOptions().getDelayMillis());
 
-        Document document = PageHelper.getDocument(configuration, connection, currentNode.getUrl(), currentNode.getReferrer(),
-                                                   new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath));
+        Document document = PageFetchServiceFactory.getService(connection).getPageSource(currentNode.getUrl(),
+            currentNode.getReferrer(),
+            new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath));
 
         // Create Map to hold all data for the current page - this will be serialized to
         // JSON and saved to file
@@ -149,7 +151,7 @@ public class MuleCrawler extends Crawler {
 
     if(maxDepth == 0) {
 
-      if (!PageHelper.isURLValid(configuration, connection, rootNode.getUrl(), rootNode.getReferrer())) {
+      if (!PageFetchServiceFactory.getService(connection).isURLValid(rootNode.getUrl(), rootNode.getReferrer())) {
 
         return null;
       }
@@ -174,7 +176,7 @@ public class MuleCrawler extends Crawler {
 
         if(currentNode.getCurrentDepth() == maxDepth) {
 
-          if(PageHelper.isURLValid(configuration, connection, currentNode.getUrl(), currentNode.getReferrer())) {
+          if(PageFetchServiceFactory.getService(connection).isURLValid(currentNode.getUrl(), currentNode.getReferrer())) {
 
             // Add as child to parent node only if valid
             SiteNode parentNode = currentNode.getParent();
@@ -188,8 +190,9 @@ public class MuleCrawler extends Crawler {
         // If not at max depth, find and crawl the links on the page
         if (currentNode.getCurrentDepth() < maxDepth) {
 
-          Document document = PageHelper.getDocument(configuration, connection, currentNode.getUrl(), currentNode.getReferrer(),
-             new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath));
+          Document document = PageFetchServiceFactory.getService(connection).getPageSource(currentNode.getUrl(),
+              currentNode.getReferrer(),
+              new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath));
 
           // Add as child to parent node only if valid
           SiteNode parentNode = currentNode.getParent();
@@ -341,7 +344,8 @@ public class MuleCrawler extends Crawler {
           return null;
         }
 
-        document = PageHelper.getDocument(configuration, connection, currentNode.getUrl(), currentNode.getReferrer(),
+        document = PageFetchServiceFactory.getService(connection).getPageSource(currentNode.getUrl(),
+            currentNode.getReferrer(),
             new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath));
 
         if(currentNode.getCurrentDepth() < maxDepth) {
@@ -365,7 +369,7 @@ public class MuleCrawler extends Crawler {
             }
           }
         }
-      } catch (IOException e) {
+      } catch (IOException | java.util.concurrent.ExecutionException | InterruptedException e) {
         throw new RuntimeException(e);
       }
 

--- a/src/main/java/org/mule/extension/webcrawler/internal/helper/page/PageHelper.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/helper/page/PageHelper.java
@@ -6,9 +6,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-import org.mule.extension.webcrawler.internal.config.PageLoadOptions;
 import org.mule.extension.webcrawler.internal.config.WebCrawlerConfiguration;
-import org.mule.extension.webcrawler.internal.connection.WebCrawlerConnection;
 import org.mule.extension.webcrawler.internal.constant.Constants;
 import org.mule.extension.webcrawler.internal.error.WebCrawlerErrorType;
 import org.mule.extension.webcrawler.internal.util.URLUtils;
@@ -27,7 +25,6 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
 import static org.mule.extension.webcrawler.internal.constant.Constants.OutputFormat.TEXT;
@@ -39,54 +36,6 @@ public class PageHelper {
   private static final Map<String, String> robotsTxtCache = new ConcurrentHashMap<>();
 
   private static final Map<String, Pattern> COMPILED_PATTERN_CACHE = new ConcurrentHashMap<>();
-
-  public static Document getDocument(WebCrawlerConfiguration webCrawlerConfiguration,
-                                     WebCrawlerConnection connection,
-                                     String url,
-                                     PageLoadOptions pageLoadOptions) throws IOException {
-
-    return getDocument(webCrawlerConfiguration, connection, url, connection.getReferrer(), pageLoadOptions);
-  }
-
-  public static Document getDocument(WebCrawlerConfiguration webCrawlerConfiguration,
-                                     WebCrawlerConnection connection,
-                                     String url,
-                                     String referrer,
-                                     PageLoadOptions pageLoadOptions) throws IOException {
-
-    LOGGER.debug(String.format("Retrieving JSoup Document for url %s and referer %s", url, referrer));
-    try (InputStream pageSourceInputStream = connection.getPageSource(url, referrer, pageLoadOptions)) {
-      String pageSource = new String(pageSourceInputStream.readAllBytes(), StandardCharsets.UTF_8);
-      Document document = Jsoup.parse(pageSource, url);
-
-      return document;
-    } catch (ModuleException me) {
-      throw me;
-
-    } catch (InterruptedException | ExecutionException e) {
-      throw new IOException(String.format("Error fetching page source for %s", url), e);
-    }
-  }
-
-  public static boolean isURLValid(WebCrawlerConfiguration webCrawlerConfiguration,
-                                   WebCrawlerConnection connection,
-                                   String url,
-                                   String referrer){
-
-    LOGGER.debug(String.format("Retrieving status code for url %s and referer %s", url, referrer));
-    try {
-
-      Integer urlStatusCode = connection.getUrlStatusCode(url, referrer);
-      if(urlStatusCode != 200) {
-        LOGGER.debug(String.format("URL %s is not valid. Status code: %d", url, urlStatusCode));
-      }
-      return urlStatusCode == 200;
-
-    } catch (InterruptedException | ExecutionException e) {
-      LOGGER.error(String.format("Error while checking statur for url %s", url), e);
-      return false;
-    }
-  }
 
   public static JSONArray getPageMetaTags(Document document) {
     // Create a JSONArray to hold the structured meta tags

--- a/src/main/java/org/mule/extension/webcrawler/internal/operation/PageOperations.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/operation/PageOperations.java
@@ -13,6 +13,7 @@ import org.jsoup.UnsupportedMimeTypeException;
 import org.jsoup.nodes.Document;
 import org.mule.extension.webcrawler.internal.helper.page.PageHelper;
 import org.mule.extension.webcrawler.internal.helper.parameter.PageTargetContentParameters;
+import org.mule.extension.webcrawler.internal.service.factory.PageFetchServiceFactory;
 import org.mule.extension.webcrawler.internal.util.JSONUtils;
 import org.mule.extension.webcrawler.internal.util.URLUtils;
 import org.mule.runtime.api.meta.ExpressionSupport;
@@ -83,9 +84,8 @@ public class PageOperations {
             WebCrawlerErrorType.CRAWL_ON_PAGE_DISALLOWED_ERROR);
       }
 
-      Document document = PageHelper.getDocument(configuration, connection, url,
-         new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath,
-                 javascript));
+      Document document = PageFetchServiceFactory.getService(connection).getPageSource(url, connection.getReferrer(),
+          new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath, javascript));
 
       LOGGER.debug(String.format("Returning page meta tags for url %s", url));
 
@@ -158,10 +158,8 @@ public class PageOperations {
               WebCrawlerErrorType.CRAWL_ON_PAGE_DISALLOWED_ERROR);
         }
 
-        document = PageHelper.getDocument(configuration, connection, url,
-            new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath,
-                    javascript));
-
+        document = PageFetchServiceFactory.getService(connection).getPageSource(url, connection.getReferrer(),
+            new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath, javascript));
 
         imagesJSONArray = PageHelper.downloadWebsiteImages(document, downloadPath, maxImageNumber);
 
@@ -248,9 +246,8 @@ public class PageOperations {
           documentsJSONArray.put(PageHelper.downloadFile(url, downloadPath));
         } else {
 
-          document = PageHelper.getDocument(configuration, connection, url,
-                                            new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath,
-                                                    javascript));
+          document = PageFetchServiceFactory.getService(connection).getPageSource(url, connection.getReferrer(),
+              new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath, javascript));
 
           documentsJSONArray = PageHelper.downloadFiles(document, downloadPath, maxDocumentNumber);
         }
@@ -328,9 +325,8 @@ public class PageOperations {
             WebCrawlerErrorType.CRAWL_ON_PAGE_DISALLOWED_ERROR);
       }
 
-      Document document = PageHelper.getDocument(configuration, connection, url,
-          new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath,
-                  javascript));
+      Document document = PageFetchServiceFactory.getService(connection).getPageSource(url, connection.getReferrer(),
+          new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath, javascript));
 
       return ResponseHelper.createPageResponse(
           JSONUtils.convertToJSON(
@@ -397,9 +393,8 @@ public class PageOperations {
 
       Map<String, String> contents = new HashMap<String, String>();
 
-      Document document = PageHelper.getDocument(configuration, connection, url,
-          new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath,
-                  javascript));
+      Document document = PageFetchServiceFactory.getService(connection).getPageSource(url, connection.getReferrer(),
+          new PageLoadOptions(waitOnPageLoad, waitForXPath, extractShadowDom, shadowHostXPath, javascript));
 
       String content = PageHelper.getPageContent(document,
                                                  targetContentParameters.getTags(),

--- a/src/main/java/org/mule/extension/webcrawler/internal/service/HttpPageFetchService.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/service/HttpPageFetchService.java
@@ -1,0 +1,90 @@
+package org.mule.extension.webcrawler.internal.service;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.mule.extension.webcrawler.internal.config.PageLoadOptions;
+import org.mule.extension.webcrawler.internal.connection.http.HttpConnection;
+import org.mule.runtime.http.api.client.HttpClient;
+import org.mule.runtime.http.api.client.HttpRequestOptions;
+import org.mule.runtime.http.api.domain.message.request.HttpRequest;
+import org.mule.runtime.http.api.domain.message.request.HttpRequestBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+
+public class HttpPageFetchService implements PageFetchService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpPageFetchService.class);
+
+  private final HttpConnection connection;
+
+  public HttpPageFetchService(HttpConnection connection) {
+    this.connection = connection;
+  }
+
+  @Override
+  public Document getPageSource(String url, String currentReferrer, PageLoadOptions pageLoadOptions)
+      throws IOException, ExecutionException, InterruptedException {
+
+    LOGGER.debug("Retrieving page source for url {} using http client (wait {} ms)",
+        url, pageLoadOptions != null ? pageLoadOptions.getWaitOnPageLoad() : null);
+
+    if (pageLoadOptions != null && pageLoadOptions.getWaitOnPageLoad() != null
+        && pageLoadOptions.getWaitOnPageLoad() > 0L) {
+      throw new IOException("Wait duration is not supported for HttpConnection");
+    }
+
+    HttpRequest request = buildRequest("GET", url, currentReferrer);
+    HttpRequestOptions options = buildRequestOptions();
+    HttpClient httpClient = connection.getHttpClient();
+
+    try (InputStream body = httpClient.sendAsync(request, options)
+        .thenApply(response -> {
+          if (response.getStatusCode() == 200) {
+            return response.getEntity().getContent();
+          }
+          throw new RuntimeException(response.getStatusCode() + ": " + response.getReasonPhrase());
+        }).get()) {
+      String html = new String(body.readAllBytes(), StandardCharsets.UTF_8);
+      return Jsoup.parse(html, url);
+    }
+  }
+
+  @Override
+  public Integer getUrlStatusCode(String url, String currentReferrer)
+      throws ExecutionException, InterruptedException {
+
+    LOGGER.debug("Checking url status for {} using http client", url);
+
+    HttpRequest request = buildRequest("HEAD", url, currentReferrer);
+    HttpRequestOptions options = buildRequestOptions();
+
+    return connection.getHttpClient().sendAsync(request, options)
+        .thenApply(response -> response.getStatusCode())
+        .exceptionally(e -> {
+          throw new RuntimeException(e);
+        }).get();
+  }
+
+  private HttpRequest buildRequest(String method, String url, String currentReferrer) {
+    HttpRequestBuilder builder = HttpRequest.builder().method(method).uri(url);
+    if (connection.getUserAgent() != null) {
+      builder.addHeader("User-Agent", connection.getUserAgent());
+    }
+    if (currentReferrer != null) {
+      builder.addHeader("Referrer", currentReferrer);
+    }
+    return builder.build();
+  }
+
+  private HttpRequestOptions buildRequestOptions() {
+    int timeout = connection.getTimeout();
+    return HttpRequestOptions.builder()
+        .responseTimeout(timeout != 0 ? timeout : 10000)
+        .build();
+  }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/service/PageFetchService.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/service/PageFetchService.java
@@ -1,0 +1,28 @@
+package org.mule.extension.webcrawler.internal.service;
+
+import org.jsoup.nodes.Document;
+import org.mule.extension.webcrawler.internal.config.PageLoadOptions;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Fetches a page (and its status) from the configured connection. Implementations parse the response, applying any
+ * connection-specific post-processing such as shadow-DOM injection for the WebDriver path.
+ */
+public interface PageFetchService {
+
+  Document getPageSource(String url, String currentReferrer, PageLoadOptions pageLoadOptions)
+      throws IOException, ExecutionException, InterruptedException;
+
+  Integer getUrlStatusCode(String url, String currentReferrer)
+      throws ExecutionException, InterruptedException;
+
+  default boolean isURLValid(String url, String currentReferrer) {
+    try {
+      return getUrlStatusCode(url, currentReferrer) == 200;
+    } catch (ExecutionException | InterruptedException e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/service/RemoteWebDriverPageFetchService.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/service/RemoteWebDriverPageFetchService.java
@@ -1,0 +1,186 @@
+package org.mule.extension.webcrawler.internal.service;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.mule.extension.webcrawler.internal.config.PageLoadOptions;
+import org.mule.extension.webcrawler.internal.connection.webdriver.RemoteWebDriverConnection;
+import org.mule.runtime.api.connection.ConnectionException;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+public class RemoteWebDriverPageFetchService implements PageFetchService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RemoteWebDriverPageFetchService.class);
+
+  private static final long DEFAULT_WAIT_ON_PAGE_LOAD_MS = 30000L;
+
+  private final RemoteWebDriverConnection connection;
+
+  public RemoteWebDriverPageFetchService(RemoteWebDriverConnection connection) {
+    this.connection = connection;
+  }
+
+  @Override
+  public Document getPageSource(String url, String currentReferrer, PageLoadOptions pageLoadOptions)
+      throws IOException, ExecutionException, InterruptedException {
+
+    LOGGER.debug("RemoteWebDriver fetch: {}", url);
+    try {
+      return connection.withDriver(driver -> {
+        driver.get(url);
+
+        long effectiveTimeout = Optional.ofNullable(pageLoadOptions != null ? pageLoadOptions.getWaitOnPageLoad() : null)
+            .filter(t -> t > 0)
+            .orElse(DEFAULT_WAIT_ON_PAGE_LOAD_MS);
+
+        JavascriptExecutor js = (JavascriptExecutor) driver;
+        new FluentWait<>(driver)
+            .withTimeout(Duration.ofMillis(effectiveTimeout))
+            .pollingEvery(Duration.ofMillis(500))
+            .until(d -> "complete".equals(js.executeScript("return document.readyState")));
+
+        if (pageLoadOptions != null
+            && pageLoadOptions.getWaitForXPath() != null
+            && !pageLoadOptions.getWaitForXPath().isEmpty()) {
+          waitForXPathLoad(driver, effectiveTimeout, pageLoadOptions.getWaitForXPath());
+        }
+
+        if (pageLoadOptions != null
+            && pageLoadOptions.getJavascript() != null
+            && !pageLoadOptions.getJavascript().isEmpty()) {
+          js.executeScript(pageLoadOptions.getJavascript());
+        }
+
+        String pageSource = driver.getPageSource();
+        Document document = Jsoup.parse(pageSource != null ? pageSource : "", url);
+
+        if (pageLoadOptions != null && pageLoadOptions.isExtractShadowDom()) {
+          injectAllShadowDOMs(driver, document, pageLoadOptions.getShadowHostXPath());
+        }
+        return document;
+      });
+    } catch (ConnectionException e) {
+      throw new IOException("Remote WebDriver fetch failed for URL: " + url, e);
+    } catch (RuntimeException e) {
+      throw new IOException("Remote WebDriver fetch failed for URL: " + url, e);
+    }
+  }
+
+  @Override
+  public Integer getUrlStatusCode(String url, String currentReferrer)
+      throws ExecutionException, InterruptedException {
+
+    // The remote browser doesn't expose HTTP status to the W3C protocol on plain GETs. Dispatch an in-page
+    // fetch() to harvest the status — same approach the embedded driver used.
+    try {
+      return connection.withDriver(driver -> {
+        driver.get(url);
+        JavascriptExecutor js = (JavascriptExecutor) driver;
+        Object status = js.executeScript(
+            "return fetch(arguments[0], { method: 'HEAD' })"
+                + ".then(response => response.status)"
+                + ".catch(() => 0);",
+            url);
+        return status instanceof Long ? ((Long) status).intValue() : 500;
+      });
+    } catch (Exception e) {
+      LOGGER.debug("Status check failed for {}: {}", url, e.getMessage());
+      return 500;
+    }
+  }
+
+  private static void waitForXPathLoad(WebDriver driver, long waitOnPageLoad, String waitForXPath) {
+    LOGGER.debug("Wait until {} for {} milliseconds", waitForXPath, waitOnPageLoad);
+    try {
+      new FluentWait<>(driver)
+          .withTimeout(Duration.ofMillis(waitOnPageLoad))
+          .pollingEvery(Duration.ofMillis(500))
+          .until(d -> {
+            try {
+              driver.findElement(By.xpath(waitForXPath));
+              return true;
+            } catch (NoSuchElementException e) {
+              return false;
+            }
+          });
+    } catch (TimeoutException e) {
+      LOGGER.warn("Element {} not found within the timeout period {}", waitForXPath, waitOnPageLoad);
+    }
+  }
+
+  /**
+   * Recursively injects all shadow DOMs inside a specified XPath into the jsoup document. Per-tag occurrence counts
+   * keep multiple instances of the same shadow-host tag (e.g. several {@code <my-card>} components) appended to their
+   * own jsoup element rather than collapsing onto the first one.
+   */
+  private static void injectAllShadowDOMs(WebDriver driver, Document document, String shadowHostXPath) {
+    JavascriptExecutor jsExecutor = (JavascriptExecutor) driver;
+    String hostXPath = shadowHostXPath == null ? "//*" : shadowHostXPath;
+
+    List<WebElement> shadowHosts = driver.findElements(By.xpath(hostXPath));
+    Map<String, Integer> tagCursor = new HashMap<>();
+
+    for (WebElement shadowHost : shadowHosts) {
+      Boolean hasShadowRoot = (Boolean) jsExecutor.executeScript(
+          "return arguments[0].shadowRoot !== null", shadowHost);
+      if (Boolean.TRUE.equals(hasShadowRoot)) {
+        String shadowContent = (String) jsExecutor.executeScript(
+            "return arguments[0].shadowRoot.innerHTML;", shadowHost);
+
+        String tagName = shadowHost.getTagName();
+        appendToNthJsoupElement(document, tagName, tagCursor, shadowContent);
+
+        injectNestedShadowDOMs(jsExecutor, document, shadowHost, tagCursor);
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void injectNestedShadowDOMs(JavascriptExecutor jsExecutor, Document document, WebElement shadowHost,
+                                             Map<String, Integer> tagCursor) {
+    String shadowRootContent = (String) jsExecutor.executeScript(
+        "return arguments[0].shadowRoot ? arguments[0].shadowRoot.innerHTML : null;",
+        shadowHost);
+
+    if (shadowRootContent != null) {
+      String tagName = shadowHost.getTagName();
+      appendToNthJsoupElement(document, tagName, tagCursor, shadowRootContent);
+
+      List<WebElement> nestedElements = (List<WebElement>) jsExecutor.executeScript(
+          "return Array.from(arguments[0].shadowRoot.querySelectorAll('*'))",
+          shadowHost);
+
+      for (WebElement nestedElement : nestedElements) {
+        injectNestedShadowDOMs(jsExecutor, document, nestedElement, tagCursor);
+      }
+    }
+  }
+
+  private static void appendToNthJsoupElement(Document document, String tagName, Map<String, Integer> tagCursor,
+                                              String content) {
+    int idx = tagCursor.getOrDefault(tagName, 0);
+    Elements matches = document.select(tagName);
+    Element target = idx < matches.size() ? matches.get(idx) : document.selectFirst(tagName);
+    if (target != null) {
+      target.append(content);
+    }
+    tagCursor.put(tagName, idx + 1);
+  }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/service/factory/PageFetchServiceFactory.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/service/factory/PageFetchServiceFactory.java
@@ -1,0 +1,20 @@
+package org.mule.extension.webcrawler.internal.service.factory;
+
+import org.mule.extension.webcrawler.internal.connection.WebCrawlerConnection;
+import org.mule.extension.webcrawler.internal.connection.http.HttpConnection;
+import org.mule.extension.webcrawler.internal.connection.webdriver.RemoteWebDriverConnection;
+import org.mule.extension.webcrawler.internal.service.HttpPageFetchService;
+import org.mule.extension.webcrawler.internal.service.PageFetchService;
+import org.mule.extension.webcrawler.internal.service.RemoteWebDriverPageFetchService;
+
+public final class PageFetchServiceFactory {
+
+  private PageFetchServiceFactory() {}
+
+  public static PageFetchService getService(WebCrawlerConnection connection) {
+    if (connection instanceof RemoteWebDriverConnection) {
+      return new RemoteWebDriverPageFetchService((RemoteWebDriverConnection) connection);
+    }
+    return new HttpPageFetchService((HttpConnection) connection);
+  }
+}


### PR DESCRIPTION
Introduce a new connection sub-type that drives a remote Selenium W3C WebDriver endpoint (Selenium Grid 4, standalone ChromeDriver, BrowserStack/ Sauce Labs, or a CloudHub-hosted remote-browser app). Chromium-only.

New types:
  - internal/connection/webdriver/RemoteWebDriverConnection.java Driver caching across calls; per-request session-readiness wait via document.readyState; optional waitForXPath + javascript hooks; shadow- DOM injection (recursive, per-tag indexed); session recovery (drops the driver without quit() on session-fatal errors and rebuilds on the next call).
  - internal/connection/webdriver/RemoteWebDriverConnectionProvider.java @Alias("remote-webdriver-connection"). Three parameters: remoteUrl (required), userAgent, referrer. Vanilla W3C session creation with ChromeOptions — no CloudHub-specific capabilities, no auth wiring.
  - internal/connection/WebCrawlerResponse.java Internal POJO carrying status code + content-type + body for the new fetchPage(...) method.

Interface change:
  - WebCrawlerConnection gains fetchPage(...) returning WebCrawlerResponse. HttpConnection implements it (status + Content-Type header + body InputStream from the HTTP response). RemoteWebDriverConnection implements it returning 200 + text/html sentinels (the W3C protocol doesn't surface the navigation's HTTP status).

Wiring:
  - WebCrawlerConfiguration adds RemoteWebDriverConnectionProvider.class to @ConnectionProviders.
  - PageHelper.getDocument re-introduces a "RemoteWebDriverConnection instanceof" branch that calls injectAllShadowDOMs(...) when extractShadowDom=true, restoring the shadow-DOM extraction behavior that the embedded driver had.

Build:
  - Parent: org.mule.extensions:mule-modules-parent:1.5.1 -> com.mulesoft.connectors:mule4-connectors-parent:5.0.4.
  - jdk.version=11, runtimeVersion=4.6.27, mule.sdk.version=1.5.1, mule.api.version=1.5.1, muleJavaEeBomVersion=4.6.0.
  - Dependency management: mule-javaee-runtime-bom imported; byte-buddy pinned to 1.14.0 (Selenium 4.35 transitively pulls a newer one whose stricter method resolution breaks the Mule SDK annotation processor).
  - Selenium: drop the umbrella selenium-java; pull granular artifacts instead (selenium-api, selenium-chrome-driver, selenium-remote-driver with Netty native-transport exclusions, selenium-support, plus selenium-devtools-v139 for the dormant authenticator implementations).
  - commons-compress dropped — was only used by the deleted CloudHubChromeConfigurer.
  - MUnit plugin override: -Dotel.logs.exporter=none reaches the forked JVM so Selenium's OpenTelemetry autoconfigure doesn't fail looking for an OTLP logs exporter.