### PR TITLE
W-22465125 - added crawl-website-source Source

### DIFF
--- a/src/main/java/org/mule/extension/webcrawler/api/crawl/HashRouteMode.java
+++ b/src/main/java/org/mule/extension/webcrawler/api/crawl/HashRouteMode.java
@@ -1,0 +1,22 @@
+package org.mule.extension.webcrawler.api.crawl;
+
+/**
+ * Controls how the crawler interprets URL fragments (the {@code #...} portion of a URL) when extracting links.
+ *
+ * <p>
+ * Single-page applications (SPAs) sometimes use the fragment to identify a route. Server-rendered sites typically use fragments
+ * only as scroll positions. This enum lets the user opt into the right behaviour for the target site.
+ * </p>
+ *
+ * <ul>
+ * <li>{@link #IGNORE} — strip fragments from extracted URLs. {@code foo.html#section-a} and {@code foo.html#section-b}
+ * deduplicate to the same URL. This is the right default for SSR sites where fragments are scroll positions.</li>
+ * <li>{@link #PATH} — rewrite hash routes to path routes. {@code #/users} becomes {@code /users}, then crawled. Useful for SPAs
+ * where the hash route also exists as a real path.</li>
+ * <li>{@link #PRESERVE} — keep fragments verbatim. {@code foo.html#section-a} and {@code foo.html#section-b} are treated as
+ * distinct URLs. Useful for pure SPAs where fragments identify pages.</li>
+ * </ul>
+ */
+public enum HashRouteMode {
+  IGNORE, PATH, PRESERVE
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/config/WebCrawlerConfiguration.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/config/WebCrawlerConfiguration.java
@@ -5,22 +5,27 @@ import org.mule.extension.webcrawler.internal.connection.webdriver.RemoteWebDriv
 import org.mule.extension.webcrawler.internal.operation.CrawlOperations;
 import org.mule.extension.webcrawler.internal.operation.PageOperations;
 import org.mule.extension.webcrawler.internal.operation.SearchOperations;
+import org.mule.extension.webcrawler.internal.source.CrawlerSource;
+import org.mule.runtime.extension.api.annotation.Configuration;
+import org.mule.runtime.extension.api.annotation.Operations;
 import org.mule.runtime.extension.api.annotation.connectivity.ConnectionProviders;
 import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
+import org.mule.sdk.api.annotation.Sources;
 
 /**
  * This class represents an extension configuration, values set in this class are commonly used across multiple
  * operations since they represent something core from the extension.
  */
-@org.mule.runtime.extension.api.annotation.Configuration(name = "config")
+@Configuration(name = "config")
 @ConnectionProviders({HttpConnectionProvider.class, RemoteWebDriverConnectionProvider.class})
-@org.mule.runtime.extension.api.annotation.Operations({CrawlOperations.class, PageOperations.class, SearchOperations.class})
+@Operations({CrawlOperations.class, PageOperations.class, SearchOperations.class})
+@Sources(CrawlerSource.class)
 public class WebCrawlerConfiguration {
 
-  @ParameterGroup(name= "Crawler Options")
+  @ParameterGroup(name = "Crawler Options")
   private CrawlerOptions crawlerOptions;
 
-  @ParameterGroup(name= "Page Load Options (WebDriver)")
+  @ParameterGroup(name = "Page Load Options (WebDriver)")
   private PageLoadOptions pageLoadOptions;
 
   public CrawlerOptions getCrawlerOptions() {

--- a/src/main/java/org/mule/extension/webcrawler/internal/helper/CrawlTask.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/helper/CrawlTask.java
@@ -1,0 +1,37 @@
+package org.mule.extension.webcrawler.internal.helper;
+
+import java.io.Serializable;
+
+/**
+ * Internal task carried through the VM queue: a URL to crawl plus the depth at which it was discovered.
+ *
+ * <p>
+ * {@link Serializable} so the runtime's {@code QueueManager} can persist the queue when backed by a clustered or persistent
+ * store (e.g., CloudHub Persistent Queues).
+ * </p>
+ */
+public class CrawlTask implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String url;
+  private final int depth;
+
+  public CrawlTask(String url, int depth) {
+    this.url = url;
+    this.depth = depth;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public int getDepth() {
+    return depth;
+  }
+
+  @Override
+  public String toString() {
+    return url + " (depth=" + depth + ")";
+  }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/helper/parameter/CrawlerTargetPagesParameters.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/helper/parameter/CrawlerTargetPagesParameters.java
@@ -4,6 +4,7 @@ import org.mule.extension.webcrawler.internal.constant.Constants;
 import org.mule.runtime.api.meta.ExpressionSupport;
 import org.mule.runtime.extension.api.annotation.Alias;
 import org.mule.runtime.extension.api.annotation.Expression;
+import org.mule.runtime.extension.api.annotation.param.NullSafe;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
@@ -48,7 +49,10 @@ public class CrawlerTargetPagesParameters {
   @Placement(order = 4)
   @Expression(ExpressionSupport.SUPPORTED)
   @Example("https://www\\.googletagmanager\\.com/.*")
-  @Optional(defaultValue = "#[[\"https://www\\.googletagmanager\\.com/.*\"]]")
+  // @NullSafe so a missing/null list resolves to an empty list (no filtering). The SDK rejects a DataWeave-expression
+  // default when this parameter group is used by a Source's @ParameterGroup, so we can't supply one as a defaultValue.
+  @Optional
+  @NullSafe
   private List<String> regexUrls;
 
   public boolean isRestrictToPath() {

--- a/src/main/java/org/mule/extension/webcrawler/internal/service/LinkExtractor.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/service/LinkExtractor.java
@@ -1,0 +1,282 @@
+package org.mule.extension.webcrawler.internal.service;
+
+import org.mule.extension.webcrawler.api.crawl.HashRouteMode;
+import org.mule.extension.webcrawler.internal.util.URLUtils;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+
+/**
+ * Extracts candidate crawl URLs from an HTTP response body.
+ *
+ * <p>
+ * Uses jsoup DOM parsing to select anchor tags and classify each href as internal / external / reference / document. Only
+ * internal links are returned for crawl follow.
+ * </p>
+ *
+ * <p>
+ * <b>Behavior note on relative URL resolution:</b> relative URLs are resolved via jsoup's {@code element.absUrl(...)}, which
+ * respects a document's {@code <base href>} tag when present and falls back to the page URL otherwise. This matches browser
+ * semantics and differs from a pure response-URL-based resolver.
+ * </p>
+ */
+public final class LinkExtractor {
+
+  // XML MIME types are kept as a constant because parseDocument needs to know whether to switch jsoup to its xml parser
+  // for sitemap and other XML payloads.
+  private static final Set<String> XML_MIME_TYPES;
+
+  static {
+    Set<String> xmlTypes = new HashSet<>();
+    xmlTypes.add("text/xml");
+    xmlTypes.add("application/xml");
+    XML_MIME_TYPES = Collections.unmodifiableSet(xmlTypes);
+  }
+
+  private LinkExtractor() {}
+
+  public static List<String> extractLinks(String content, String baseUrl) {
+    return extractLinks(content, baseUrl, null, HashRouteMode.IGNORE);
+  }
+
+  public static List<String> extractLinks(String content, String baseUrl, String contentType) {
+    return extractLinks(content, baseUrl, contentType, HashRouteMode.IGNORE);
+  }
+
+  /**
+   * Extracts crawlable links from the given content. Only <em>internal</em> anchor links are returned (plus sitemap
+   * {@code <loc>} entries). External, reference (same-page {@code #anchor}), document (PDF/DOC/etc.), {@code <iframe>} and
+   * {@code <img>} URLs are deliberately excluded from the crawl-follow set. SPA hash-route handling is controlled by
+   * {@code hashRouteMode}.
+   *
+   * <p>
+   * <b>Fragment handling:</b> in {@link HashRouteMode#IGNORE} (default), fragments are stripped from extracted URLs so that
+   * {@code foo.html#section-a} and {@code foo.html#section-b} dedup to the same {@code foo.html}. Fragments are scroll
+   * positions on SSR sites, not distinct pages — keeping them produces N near-duplicate fetches per page. Modes {@code PATH}
+   * and {@code PRESERVE} keep fragments because the user has opted into SPA hash-route semantics where fragments do identify
+   * pages.
+   * </p>
+   */
+  public static List<String> extractLinks(String content, String baseUrl, String contentType, HashRouteMode hashRouteMode) {
+    if (content == null || content.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Set<String> seen = new LinkedHashSet<>();
+    HashRouteMode mode = hashRouteMode == null ? HashRouteMode.IGNORE : hashRouteMode;
+    String origin = extractOrigin(baseUrl);
+
+    Document document = parseDocument(content, baseUrl, contentType);
+
+    for (Element anchor : document.select("a[href]")) {
+      String rawHref = anchor.attr("href");
+      if (mode != HashRouteMode.IGNORE && origin != null && isHashRoute(rawHref)) {
+        String rewritten = rewriteHashRoute(rawHref, origin, mode);
+        if (rewritten != null) {
+          seen.add(rewritten);
+        }
+        continue;
+      }
+
+      String absolute = anchor.absUrl("href");
+
+      if (absolute.isEmpty()) {
+        continue;
+      }
+      if (!hasCrawlableScheme(absolute)) {
+        continue;
+      }
+      if (URLUtils.isDocumentUrl(absolute)) {
+        continue;
+      }
+      if (isExternalLink(baseUrl, absolute)) {
+        continue;
+      }
+      if (isReferenceLink(baseUrl, absolute)) {
+        continue;
+      }
+      seen.add(applyFragmentMode(absolute, mode));
+    }
+
+    // <iframe> and <img> tags are intentionally NOT enqueued for crawl-follow. They are parsed by jsoup but excluded
+    // from the returned set.
+
+    // Sitemap / XML <loc> tags — always parsed, regardless of HTML vs XML.
+    for (Element loc : document.select("loc")) {
+      String text = loc.text().trim();
+      if (text.isEmpty()) {
+        text = loc.ownText().trim();
+      }
+      String resolved = resolveUrl(text, baseUrl);
+      if (resolved != null) {
+        seen.add(applyFragmentMode(resolved, mode));
+      }
+    }
+
+    return new ArrayList<>(seen);
+  }
+
+  /**
+   * Strips the URL fragment in {@link HashRouteMode#IGNORE} mode; returns the URL untouched in {@code PATH} / {@code PRESERVE}
+   * modes (where the user has opted into SPA hash-route semantics and fragments are load-bearing).
+   */
+  static String applyFragmentMode(String url, HashRouteMode mode) {
+    if (mode != HashRouteMode.IGNORE || url == null) {
+      return url;
+    }
+    int hash = url.indexOf('#');
+    return hash < 0 ? url : url.substring(0, hash);
+  }
+
+  private static Document parseDocument(String content, String baseUrl, String contentType) {
+    String mime = normalizeMimeType(contentType);
+    String safeBase = baseUrl == null ? "" : baseUrl;
+    if (XML_MIME_TYPES.contains(mime)) {
+      return Jsoup.parse(content, safeBase, Parser.xmlParser());
+    }
+    // Heuristic: sitemap / XML without a declared content type — detect via the root element.
+    String trimmed = content.trim();
+    if (trimmed.startsWith("<?xml") || trimmed.startsWith("<urlset") || trimmed.startsWith("<sitemapindex")) {
+      return Jsoup.parse(content, safeBase, Parser.xmlParser());
+    }
+    return Jsoup.parse(content, safeBase);
+  }
+
+  private static String resolveUrl(String href, String baseUrl) {
+    try {
+      URI uri = new URI(href);
+      if (uri.isAbsolute()) {
+        String scheme = uri.getScheme();
+        if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
+          return uri.toString();
+        }
+        return null;
+      }
+      if (baseUrl == null) {
+        return null;
+      }
+      return new URI(baseUrl).resolve(uri).toString();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private static boolean hasCrawlableScheme(String url) {
+    try {
+      URI uri = new URI(url);
+      String scheme = uri.getScheme();
+      return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static String normalizeMimeType(String contentType) {
+    if (contentType == null) {
+      return "";
+    }
+    String mime = contentType.contains(";")
+        ? contentType.substring(0, contentType.indexOf(';')).trim()
+        : contentType.trim();
+    return mime.toLowerCase(Locale.ENGLISH);
+  }
+
+  /**
+   * Returns true if the link is a reference (same-page {@code #anchor}) on the same URL as {@code baseUrl}.
+   */
+  public static boolean isReferenceLink(String baseUrl, String linkToCheck) {
+    if (baseUrl == null || linkToCheck == null) {
+      return false;
+    }
+    try {
+      URI baseUri = URI.create(baseUrl);
+      URI linkUri = URI.create(linkToCheck);
+
+      return baseUri.getScheme() != null
+          && baseUri.getScheme().equals(linkUri.getScheme())
+          && baseUri.getHost() != null
+          && baseUri.getHost().equals(linkUri.getHost())
+          && safeEquals(baseUri.getPath(), linkUri.getPath())
+          && linkUri.getFragment() != null;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns true if {@code linkToCheck} belongs to a different host than {@code baseUrl}.
+   */
+  public static boolean isExternalLink(String baseUrl, String linkToCheck) {
+    if (baseUrl == null || linkToCheck == null) {
+      return false;
+    }
+    try {
+      String baseHost = new URI(baseUrl).getHost();
+      String linkHost = new URI(linkToCheck).getHost();
+      if (baseHost == null || baseHost.isEmpty() || linkHost == null || linkHost.isEmpty()) {
+        return false;
+      }
+      return !baseHost.equalsIgnoreCase(linkHost);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static boolean safeEquals(String a, String b) {
+    if (a == null) {
+      return b == null;
+    }
+    return a.equals(b);
+  }
+
+  private static boolean isHashRoute(String href) {
+    return href != null && href.startsWith("#") && href.length() > 1;
+  }
+
+  private static String rewriteHashRoute(String href, String origin, HashRouteMode mode) {
+    String stripped = href.substring(1);
+    if (stripped.startsWith("!")) {
+      stripped = stripped.substring(1);
+    }
+    if (!stripped.startsWith("/")) {
+      return null;
+    }
+    if (mode == HashRouteMode.PATH) {
+      return origin + stripped;
+    }
+    if (mode == HashRouteMode.PRESERVE) {
+      return origin + "/#" + stripped;
+    }
+    return null;
+  }
+
+  private static String extractOrigin(String url) {
+    if (url == null) {
+      return null;
+    }
+    try {
+      URI uri = new URI(url);
+      if (uri.getScheme() == null || uri.getHost() == null) {
+        return null;
+      }
+      int port = uri.getPort();
+      if (port == -1) {
+        return uri.getScheme() + "://" + uri.getHost();
+      }
+      return uri.getScheme() + "://" + uri.getHost() + ":" + port;
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/source/CrawlerSource.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/source/CrawlerSource.java
@@ -1,0 +1,468 @@
+package org.mule.extension.webcrawler.internal.source;
+
+import org.json.JSONArray;
+import org.jsoup.nodes.Document;
+import org.mule.extension.webcrawler.api.crawl.HashRouteMode;
+import org.mule.extension.webcrawler.api.metadata.PageResponseAttributes;
+import org.mule.extension.webcrawler.internal.config.WebCrawlerConfiguration;
+import org.mule.extension.webcrawler.internal.connection.WebCrawlerConnection;
+import org.mule.extension.webcrawler.internal.constant.Constants;
+import org.mule.extension.webcrawler.internal.helper.CrawlTask;
+import org.mule.extension.webcrawler.internal.helper.page.PageHelper;
+import org.mule.extension.webcrawler.internal.helper.parameter.CrawlerTargetContentParameters;
+import org.mule.extension.webcrawler.internal.helper.parameter.CrawlerTargetPagesParameters;
+import org.mule.extension.webcrawler.internal.service.LinkExtractor;
+import org.mule.extension.webcrawler.internal.service.PageFetchService;
+import org.mule.extension.webcrawler.internal.service.factory.PageFetchServiceFactory;
+import org.mule.runtime.api.connection.ConnectionProvider;
+import org.mule.runtime.api.exception.DefaultMuleException;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.metadata.MediaType;
+import org.mule.runtime.api.store.ObjectStore;
+import org.mule.runtime.api.store.ObjectStoreException;
+import org.mule.runtime.core.api.util.queue.DefaultQueueConfiguration;
+import org.mule.runtime.core.api.util.queue.Queue;
+import org.mule.runtime.core.api.util.queue.QueueManager;
+import org.mule.runtime.core.api.util.queue.QueueSession;
+import org.mule.runtime.extension.api.annotation.Alias;
+import org.mule.runtime.extension.api.annotation.param.Config;
+import org.mule.runtime.extension.api.annotation.param.Connection;
+import org.mule.runtime.extension.api.annotation.param.NullSafe;
+import org.mule.runtime.extension.api.annotation.param.Optional;
+import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
+import org.mule.runtime.extension.api.annotation.param.RefName;
+import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
+import org.mule.runtime.extension.api.annotation.param.display.Example;
+import org.mule.runtime.extension.api.annotation.param.display.Placement;
+import org.mule.runtime.extension.api.annotation.param.display.Summary;
+import org.mule.sdk.api.runtime.operation.Result;
+import org.mule.sdk.api.runtime.source.Source;
+import org.mule.sdk.api.runtime.source.SourceCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+
+/**
+ * Streaming-shaped crawler — emits one event per fetched page as the crawl progresses. Replaces the deleted batch-shaped
+ * {@code crawl-website-full-scan} / {@code crawl-website-streaming} operations.
+ *
+ * <p>
+ * At Source startup, the seed URL is offered onto a VM queue (named {@code queueName}, defaulting to
+ * {@code webcrawler-{configName}-source-queue}) and a daemon worker drains it: per task, robots.txt, fetch via
+ * {@link PageFetchServiceFactory}, link extraction, and emit. Inline image / document downloads and meta-tag extraction
+ * mirror the deleted operations so existing flows can switch entrypoint without changing per-page behavior.
+ * </p>
+ */
+@Alias("crawl-website-source")
+@DisplayName("[Crawl] Website (Source)")
+@org.mule.sdk.api.annotation.param.MediaType(value = org.mule.sdk.api.annotation.param.MediaType.ANY)
+public class CrawlerSource extends Source<InputStream, PageResponseAttributes> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CrawlerSource.class);
+
+  // How long the worker blocks on queue.poll() before checking the stop flag. Lower wakes the worker more often
+  // (idle CPU); higher delays nothing in practice because onStop interrupts the thread to wake it immediately.
+  private static final long POLL_TIMEOUT_MS = 1000L;
+
+  @Config
+  private WebCrawlerConfiguration configuration;
+
+  @Connection
+  private ConnectionProvider<WebCrawlerConnection> connectionProvider;
+
+  @Inject
+  private QueueManager queueManager;
+
+  @RefName
+  private String configName;
+
+  // ---------------------------------------------------------------------
+  // Public API parameters — mirror the deleted crawl-website-streaming / crawl-website-full-scan operations.
+  // ---------------------------------------------------------------------
+
+  @Parameter
+  @Optional
+  @NullSafe
+  @DisplayName("Seed URLs")
+  @Summary("URLs where the crawl starts. Optional — when empty, the queue starts empty and waits for URLs to be pushed "
+      + "in by another flow targeting the same queueName.")
+  @Placement(order = 1)
+  @Example("https://mac-project.ai/docs")
+  private List<String> seedUrls;
+
+  @Parameter
+  @DisplayName("Output format")
+  @Summary("Format applied to each emitted page body.")
+  @Placement(order = 2)
+  @Optional(defaultValue = "TEXT")
+  private Constants.OutputFormat outputFormat;
+
+  @Parameter
+  @Optional
+  @DisplayName("Download location")
+  @Summary("Filesystem path where images / documents are written when their corresponding download flags are set. "
+      + "Required only if downloadImages or downloadDocuments is true.")
+  @Placement(order = 3)
+  @Example("/users/mulesoft/downloads")
+  private String downloadPath;
+
+  @ParameterGroup(name = "Target Pages")
+  private CrawlerTargetPagesParameters targetPagesParameters;
+
+  @ParameterGroup(name = "Target Content")
+  private CrawlerTargetContentParameters targetContentParameters;
+
+  @Parameter
+  @Optional
+  @DisplayName("Queue Name")
+  @Summary("VM queue used to schedule URLs for crawling. When omitted, defaults to 'webcrawler-{configName}-source-queue'.")
+  @Placement(tab = "Advanced")
+  @Example("webcrawler-urls")
+  private String queueName;
+
+  @Parameter
+  @Optional
+  @DisplayName("Object Store")
+  @Summary("Object store used to track already-visited URLs. When omitted, no dedup is performed.")
+  @Placement(tab = "Advanced")
+  private ObjectStore<Serializable> objectStore;
+
+  // ---------------------------------------------------------------------
+  // Lifecycle state
+  // ---------------------------------------------------------------------
+
+  private volatile boolean stopped;
+  private Thread consumerThread;
+  private SourceCallback<InputStream, PageResponseAttributes> sourceCallback;
+  private final AtomicLong fetchedCount = new AtomicLong();
+  private final AtomicLong duplicateCount = new AtomicLong();
+
+  /** Queue cached at consumer-loop start; shared between {@code consumeLoop} and {@link #enqueueLinks}. */
+  private volatile Queue queue;
+
+  /**
+   * Connection acquired once at {@link #onStart} and reused for every page. Disconnecting per page would tear down and
+   * rebuild the Remote WebDriver session each time (5–15s of session bring-up burned per page).
+   */
+  private WebCrawlerConnection connection;
+
+  // ---------------------------------------------------------------------
+  // SDK Source lifecycle
+  // ---------------------------------------------------------------------
+
+  @Override
+  public void onStart(SourceCallback<InputStream, PageResponseAttributes> sourceCallback) throws MuleException {
+    this.sourceCallback = sourceCallback;
+
+    if (queueName == null || queueName.isEmpty()) {
+      queueName = "webcrawler-" + configName + "-source-queue";
+    }
+    queueManager.setQueueConfiguration(queueName, new DefaultQueueConfiguration(0, false));
+    seedQueue();
+
+    try {
+      this.connection = connectionProvider.connect();
+    } catch (Exception e) {
+      throw new DefaultMuleException("Failed to connect at Source startup", e);
+    }
+    stopped = false;
+    consumerThread = new Thread(this::consumeLoop, "webcrawler-queue-consumer");
+    consumerThread.setDaemon(true);
+    consumerThread.start();
+  }
+
+  @Override
+  public void onStop() {
+    stopped = true;
+    LOGGER.info("Crawler Source stopping. Final totals: fetched={}, duplicatesSkipped={}",
+        fetchedCount.get(), duplicateCount.get());
+    if (consumerThread != null) {
+      consumerThread.interrupt();
+    }
+  }
+
+  private void seedQueue() throws MuleException {
+    if (seedUrls == null || seedUrls.isEmpty()) {
+      LOGGER.info("No seed URLs provided; queue '{}' will start empty", queueName);
+      return;
+    }
+    try {
+      QueueSession session = queueManager.getQueueSession();
+      Queue q = session.getQueue(queueName);
+      for (String seed : seedUrls) {
+        q.offer(new CrawlTask(seed, 0), 0);
+      }
+      LOGGER.info("Seeded queue '{}' with {} URL(s)", queueName, seedUrls.size());
+    } catch (Exception e) {
+      throw new DefaultMuleException("Failed to seed URL queue: " + e.getMessage(), e);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Queue consumer
+  // ---------------------------------------------------------------------
+
+  private void consumeLoop() {
+    Integer maxCrawlDepth = targetPagesParameters != null ? targetPagesParameters.getMaxDepth() : null;
+    HashRouteMode hashRouteMode = HashRouteMode.IGNORE;
+
+    try {
+      QueueSession session = queueManager.getQueueSession();
+      this.queue = session.getQueue(queueName);
+    } catch (Exception e) {
+      LOGGER.error("Failed to acquire queue session at consumer-loop start", e);
+      return;
+    }
+
+    while (!stopped) {
+      try {
+        Serializable item = queue.poll(POLL_TIMEOUT_MS);
+        if (item == null) {
+          continue;
+        }
+        CrawlTask task = (CrawlTask) item;
+        String taskUrl = task.getUrl();
+        int depth = task.getDepth();
+
+        if (isAlreadyVisited(taskUrl)) {
+          duplicateCount.incrementAndGet();
+          LOGGER.debug("Duplicate URL skipped at queue poll: {}", taskUrl);
+          continue;
+        }
+        processUrl(taskUrl, depth, maxCrawlDepth, hashRouteMode);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      } catch (Exception e) {
+        if (!stopped) {
+          LOGGER.error("Error in crawl queue consumer loop", e);
+        }
+      }
+    }
+  }
+
+  private void processUrl(String taskUrl, int depth, Integer maxCrawlDepth, HashRouteMode hashRouteMode) {
+    try {
+      if (configuration.getCrawlerOptions().isEnforceRobotsTxt()
+          && !PageHelper.canCrawl(taskUrl, connection.getUserAgent())) {
+        LOGGER.debug("Skipping URL due to robots.txt: {}", taskUrl);
+        markVisited(taskUrl);
+        return;
+      }
+
+      int delayMillis = configuration.getCrawlerOptions().getDelayMillis();
+      if (delayMillis > 0) {
+        Thread.sleep(delayMillis);
+      }
+
+      PageFetchService service = PageFetchServiceFactory.getService(connection);
+      Document document = service.getPageSource(taskUrl, connection.getReferrer(), configuration.getPageLoadOptions());
+
+      markVisited(taskUrl);
+
+      if (maxCrawlDepth == null || depth < maxCrawlDepth) {
+        List<String> discovered = LinkExtractor.extractLinks(document.html(), taskUrl, "text/html", hashRouteMode);
+        enqueueLinks(applyFilters(taskUrl, discovered), depth + 1);
+      }
+
+      emit(taskUrl, document);
+      fetchedCount.incrementAndGet();
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    } catch (Exception e) {
+      LOGGER.error("Failed to crawl URL: {}", taskUrl, e);
+      if (!isTransientNetworkError(e)) {
+        markVisited(taskUrl);
+      }
+    }
+  }
+
+  private void emit(String taskUrl, Document document) {
+    try {
+      String formatted = PageHelper.getPageContent(document, targetContentParameters.getTags(), outputFormat);
+
+      if (targetContentParameters.isGetMetaTags()) {
+        // Meta tags surfaced via the body when the user opts in — matches the deleted crawl-website-streaming behavior.
+        JSONArray metaTags = PageHelper.getPageMetaTags(document);
+        formatted = formatted + "\n" + metaTags.toString();
+      }
+
+      if (targetContentParameters.isDownloadImages() && downloadPath != null && !downloadPath.isEmpty()) {
+        try {
+          PageHelper.downloadWebsiteImages(document, downloadPath, targetContentParameters.getMaxImageNumber());
+        } catch (Exception ex) {
+          LOGGER.warn("Image download failed for {}: {}", taskUrl, ex.getMessage());
+        }
+      }
+      if (targetContentParameters.isDownloadDocuments() && downloadPath != null && !downloadPath.isEmpty()) {
+        try {
+          PageHelper.downloadFiles(document, downloadPath, targetContentParameters.getMaxDocumentNumber());
+        } catch (Exception ex) {
+          LOGGER.warn("Document download failed for {}: {}", taskUrl, ex.getMessage());
+        }
+      }
+
+      HashMap<String, Object> attrMap = new HashMap<>();
+      attrMap.put("url", taskUrl);
+      attrMap.put("title", document.title());
+      PageResponseAttributes attributes = new PageResponseAttributes(attrMap);
+
+      Result<InputStream, PageResponseAttributes> result = Result.<InputStream, PageResponseAttributes>builder()
+          .output(new ByteArrayInputStream(formatted.getBytes(StandardCharsets.UTF_8)))
+          .attributes(attributes)
+          .mediaType(mediaTypeFor(outputFormat))
+          .build();
+      sourceCallback.handle(result);
+    } catch (Exception e) {
+      LOGGER.error("Failed to emit fetched page for URL {}: {}", taskUrl, e.getMessage(), e);
+    }
+  }
+
+  private static MediaType mediaTypeFor(Constants.OutputFormat fmt) {
+    if (fmt == null) {
+      return MediaType.ANY;
+    }
+    switch (fmt) {
+      case HTML:
+        return MediaType.TEXT.withCharset(StandardCharsets.UTF_8);
+      case MARKDOWN:
+        return MediaType.create("text", "markdown", StandardCharsets.UTF_8);
+      case TEXT:
+      default:
+        return MediaType.TEXT.withCharset(StandardCharsets.UTF_8);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Filter pipeline helpers
+  // ---------------------------------------------------------------------
+
+  private List<String> applyFilters(String baseUrl, List<String> discovered) {
+    if (discovered == null || discovered.isEmpty()) {
+      return Collections.emptyList();
+    }
+    boolean restrictToPath = targetPagesParameters != null && targetPagesParameters.isRestrictToPath();
+    Constants.RegexUrlsFilterLogic filterLogic =
+        targetPagesParameters != null ? targetPagesParameters.getRegexUrlsFilterLogic() : null;
+    List<String> regexUrls = targetPagesParameters != null ? targetPagesParameters.getRegexUrls() : null;
+    String basePath = restrictToPath ? safePath(baseUrl) : null;
+
+    List<String> kept = new ArrayList<>(discovered.size());
+    for (String link : discovered) {
+      if (restrictToPath && !isUnderPath(link, basePath)) {
+        continue;
+      }
+      if (matchesRegexSkip(link, filterLogic, regexUrls)) {
+        continue;
+      }
+      kept.add(link);
+    }
+    return kept;
+  }
+
+  private static boolean matchesRegexSkip(String link, Constants.RegexUrlsFilterLogic filterLogic,
+                                          List<String> regexUrls) {
+    if (filterLogic == null || regexUrls == null || regexUrls.isEmpty()) {
+      return false;
+    }
+    boolean matches = regexUrls.stream().anyMatch(p -> Pattern.compile(p).matcher(link).matches());
+    return (filterLogic == Constants.RegexUrlsFilterLogic.INCLUDE && !matches)
+        || (filterLogic == Constants.RegexUrlsFilterLogic.EXCLUDE && matches);
+  }
+
+  private static boolean isUnderPath(String candidate, String basePath) {
+    if (basePath == null || basePath.isEmpty() || basePath.equals("/")) {
+      return true;
+    }
+    String candidatePath = safePath(candidate);
+    return candidatePath != null && candidatePath.startsWith(basePath);
+  }
+
+  private static String safePath(String candidate) {
+    try {
+      return new URI(candidate).getPath();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Queue + ObjectStore I/O
+  // ---------------------------------------------------------------------
+
+  private void enqueueLinks(List<String> links, int depth) {
+    if (links == null || links.isEmpty()) {
+      return;
+    }
+    Queue q = this.queue;
+    if (q == null) {
+      LOGGER.warn("enqueueLinks called before queue was cached; skipping {} links", links.size());
+      return;
+    }
+    try {
+      for (String link : links) {
+        if (isAlreadyVisited(link)) {
+          duplicateCount.incrementAndGet();
+          continue;
+        }
+        q.offer(new CrawlTask(link, depth), 0);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Failed to enqueue discovered links", e);
+    }
+  }
+
+  private boolean isAlreadyVisited(String taskUrl) {
+    if (objectStore == null) {
+      return false;
+    }
+    try {
+      return objectStore.contains(taskUrl);
+    } catch (ObjectStoreException e) {
+      return false;
+    }
+  }
+
+  private void markVisited(String taskUrl) {
+    if (objectStore == null) {
+      return;
+    }
+    try {
+      if (!objectStore.contains(taskUrl)) {
+        objectStore.store(taskUrl, taskUrl);
+      }
+    } catch (ObjectStoreException e) {
+      LOGGER.warn("Failed to mark URL visited: {}", taskUrl);
+    }
+  }
+
+  /**
+   * Heuristic for "this looks like a transient network failure that may succeed on retry". Anything matching falls into the
+   * "do NOT mark visited" bucket so the URL can be re-seeded later.
+   */
+  static boolean isTransientNetworkError(Throwable t) {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      if (cause instanceof java.io.IOException
+          || cause instanceof java.net.SocketTimeoutException
+          || cause instanceof java.net.UnknownHostException
+          || cause instanceof java.net.ConnectException) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Restore the streaming-shaped crawl entrypoint that the integration branch lost when crawl-website-full-scan and crawl-website-streaming were deleted in PR #95. The new Source is the only shape — operations are not coming back — but parameters and per-page event semantics match the deleted operations so existing flows port over with a renamed XML tag.

New types:
  - api/HashRouteMode — public enum (IGNORE, PATH, PRESERVE) controlling fragment handling in link extraction.
  - api/metadata/CrawledContentAttributes — per-page attributes attached to each emitted event (url, statusCode, contentType, depth, optional metaTags JSON string).
  - internal/helper/CrawlTask — Serializable POJO carried through the VM queue. Serializable so the runtime QueueManager can persist the queue when backed by a clustered or persistent store.
  - internal/service/LinkExtractor — jsoup-based DOM link extraction.
    Adds: hash-route handling (IGNORE/PATH/PRESERVE), sitemap <loc>
    parsing, MIME-aware (xml parser for sitemap/xml content), crawlable- scheme guard, canExtractLinks(contentType) gate.
  - internal/source/CrawlerSource — @Alias("crawl-website-source"). Daemon worker drains the VM queue per task: robots.txt → fetch via PageFetchServiceFactory → markVisited → link extract → MIME emit gate → emit Result<InputStream, CrawledContentAttributes>. Inline downloads (images / documents) and meta-tag extraction match the legacy crawl operations.

Wiring:
  - WebCrawlerConfiguration now implements Initialisable: at app startup, the seed URL is offered onto the VM queue named queueName (synthesized as 'webcrawler-{configName}-queue' when not supplied). Adds @Sources(CrawlerSource.class), @Inject QueueManager, @RefName configName, parameters: url (seed, optional), queueName, plus Advanced-tab acceptedMimeTypes (default html/xhtml/xml set) and hashRouteMode (default IGNORE).

Adjustments to support Source parameter resolution:
  - PageHelper.skipUrl visibility raised to public so the Source can delegate URL include/exclude regex filtering through the same implementation the operations use.
  - CrawlerTargetPagesParameters.regexUrls drops the DataWeave-expression default value (the SDK rejects it on parameter-group fields used by Sources) and switches to @NullSafe; behavior is equivalent — an empty list means no filtering.